### PR TITLE
Refactor friendship filter usage in AdminPanel

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -98,6 +98,41 @@ export function AdminPanel() {
     fetchProfiles();
   };
 
+  const handleAddFriend = async (friendManagerUser: Profile, friendId: string) => {
+    const friendshipFilter = `user_a_id.eq.${friendManagerUser.id},user_b_id.eq.${friendManagerUser.id}`;
+
+    const { error } = await supabase
+      .from('friendships')
+      .insert({ user_a_id: friendManagerUser.id, user_b_id: friendId })
+      .or(friendshipFilter);
+
+    if (error) {
+      toast({
+        title: "Hata",
+        description: "Arkadaş eklenirken bir hata oluştu",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleRemoveFriend = async (friendManagerUser: Profile, friendId: string) => {
+    const friendshipFilter = `user_a_id.eq.${friendManagerUser.id},user_b_id.eq.${friendManagerUser.id}`;
+
+    const { error } = await supabase
+      .from('friendships')
+      .delete()
+      .match({ user_a_id: friendManagerUser.id, user_b_id: friendId })
+      .or(friendshipFilter);
+
+    if (error) {
+      toast({
+        title: "Hata",
+        description: "Arkadaş silinirken bir hata oluştu",
+        variant: "destructive",
+      });
+    }
+  };
+
   const onUserSaved = () => {
     fetchProfiles();
     setIsDialogOpen(false);


### PR DESCRIPTION
## Summary
- ensure the friendship filter string in the AdminPanel friend handlers remains contiguous before passing it to `.or`
- update both add and remove friend handlers to share the single-line `friendshipFilter` constant

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d6e34b825083209eb7f097131e1e40